### PR TITLE
Remove const pointer cast

### DIFF
--- a/src/r.cc
+++ b/src/r.cc
@@ -218,29 +218,29 @@ istream& R::read_att(istream& is) {
 ostream& R::write_att(ostream& os) const {
   switch(type()) {
   case Type::RH:
-    return static_cast<const Rh* const>(this)->write_att(os);
+    return static_cast<const Rh*>(this)->write_att(os);
     break;
 
   case Type::R_8:
   case Type::AL:
   case Type::CL:
-    return static_cast<const R8* const>(this)->write_att(os);
+    return static_cast<const R8*>(this)->write_att(os);
     break;
 
   case Type::R_16:
   case Type::AX:
   case Type::DX:
-    return static_cast<const R16 * const>(this)->write_att(os);
+    return static_cast<const R16*>(this)->write_att(os);
     break;
 
   case Type::R_32:
   case Type::EAX:
-    return static_cast<const R32 * const>(this)->write_att(os);
+    return static_cast<const R32*>(this)->write_att(os);
     break;
 
   case Type::R_64:
   case Type::RAX:
-    return static_cast<const R64 * const>(this)->write_att(os);
+    return static_cast<const R64*>(this)->write_att(os);
     break;
 
   default:

--- a/src/sse.cc
+++ b/src/sse.cc
@@ -30,11 +30,11 @@ ostream& Sse::write_att(ostream& os) const {
   switch(type()) {
   case Type::XMM_0:
   case Type::XMM:
-    return static_cast<const Xmm * const>(this)->write_att(os);
+    return static_cast<const Xmm*>(this)->write_att(os);
     break;
 
   case Type::YMM:
-    return static_cast<const Ymm * const>(this)->write_att(os);
+    return static_cast<const Ymm*>(this)->write_att(os);
     break;
 
   default:


### PR DESCRIPTION
Hi all,

Returning a const value does not have much meaning, indeed [CppCoreGuidelines](https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#f20-for-out-output-values-prefer-return-values-to-output-parameters) notes: 

> ...
It is not recommended to return a const value. Such older advice is now obsolete; it does not add value, and it interferes with move semantics.

So the second `const` in, for example:
https://github.com/StanfordPL/x64asm/blob/505ab5e404d0c19a038b91b6690f85c7a087b8c6/src/r.cc#L221

can be removed as

```
return static_cast<const Rh*>(this)->write_att(os);
```

In recent version of `g++`, the compiler reports:

```
ccache g++ -Werror -Wextra -Wall -Wfatal-errors -pedantic -Wno-unused-parameter -Wno-reorder -std=c++11 -fPIC -DNDEBUG -O3 -I./ -c src/r.cc -o src/r.o
src/r.cc: In member function 'std::ostream& x64asm::R::write_att(std::ostream&) const':
src/r.cc:247:47: error: type qualifiers ignored on cast result type [-Werror=ignored-qualifiers]
     return static_cast<const R64 * const>(this)->write_att(os);
```

