### PR TITLE
remove superfluous const qualifiers in casts

### DIFF
--- a/src/r.cc
+++ b/src/r.cc
@@ -218,29 +218,29 @@ istream& R::read_att(istream& is) {
 ostream& R::write_att(ostream& os) const {
   switch(type()) {
   case Type::RH:
-    return static_cast<const Rh* const>(this)->write_att(os);
+    return static_cast<const Rh*>(this)->write_att(os);
     break;
 
   case Type::R_8:
   case Type::AL:
   case Type::CL:
-    return static_cast<const R8* const>(this)->write_att(os);
+    return static_cast<const R8*>(this)->write_att(os);
     break;
 
   case Type::R_16:
   case Type::AX:
   case Type::DX:
-    return static_cast<const R16 * const>(this)->write_att(os);
+    return static_cast<const R16 *>(this)->write_att(os);
     break;
 
   case Type::R_32:
   case Type::EAX:
-    return static_cast<const R32 * const>(this)->write_att(os);
+    return static_cast<const R32 *>(this)->write_att(os);
     break;
 
   case Type::R_64:
   case Type::RAX:
-    return static_cast<const R64 * const>(this)->write_att(os);
+    return static_cast<const R64 *>(this)->write_att(os);
     break;
 
   default:

--- a/src/sse.cc
+++ b/src/sse.cc
@@ -30,11 +30,11 @@ ostream& Sse::write_att(ostream& os) const {
   switch(type()) {
   case Type::XMM_0:
   case Type::XMM:
-    return static_cast<const Xmm * const>(this)->write_att(os);
+    return static_cast<const Xmm *>(this)->write_att(os);
     break;
 
   case Type::YMM:
-    return static_cast<const Ymm * const>(this)->write_att(os);
+    return static_cast<const Ymm *>(this)->write_att(os);
     break;
 
   default:


### PR DESCRIPTION
This prevents a compilation failure with g++ 13.3.0.

Example of an error fixed by this commit:

```text
ccache g++ -Werror -Wextra -Wall -Wfatal-errors -pedantic -Wno-unused-parameter -Wno-reorder -std=c++11 -fPIC -g -I./ -c src/r.cc -o src/r.o
src/r.cc: In member function ‘std::ostream& x64asm::R::write_att(std::ostream&) const’:
src/r.cc:221:12: error: type qualifiers ignored on cast result type [-Werror=ignored-qualifiers]
  221 |     return static_cast<const Rh* const>(this)->write_att(os);
      |            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated due to -Wfatal-errors.
cc1plus: all warnings being treated as errors
make[1]: *** [Makefile:75: src/r.o] Error 1
make[1]: Leaving directory '/space/daveho/git/x64asm'
make: *** [Makefile:54: debug] Error 2
```

Since the result of the cast is an rvalue, the second occurrence of `const` isn't meaningful.